### PR TITLE
increase read buffer size to 2MB

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func udpListener(address string, dataCh chan []byte) {
 	}
 	defer listener.Close()
 
-	err = listener.SetReadBuffer(1024 * 1024)
+	err = listener.SetReadBuffer(2048 * 1024)
 	if err != nil {
 		log.Printf("ERROR: SetReadBuffer - %s", err)
 	}


### PR DESCRIPTION
Noticed with many NSQ topics, we were getting UDP packet receive
errors.
We were able to reduce the errors by tuning our kernel buffers, but
noticed that after increasing our buffers past 1MB we didn't see
any further improvement.

Our working hypothesis is that this is due to the explicit 1MB
receive buffer specified by ddstatsd. For now doubling to 2MB
as we believe it will be sufficient.